### PR TITLE
修复打勾时可能会点到空白处的xpath

### DIFF
--- a/auto_checkin.py
+++ b/auto_checkin.py
@@ -92,7 +92,7 @@ def daka(un,pd,sendkey):
         # 滚动到底部
         browser.execute_script("window.scrollTo(0,document.body.clientHeight)")
         time.sleep(2)
-        browser.find_element_by_xpath('/html/body/div[1]/div/div/div[3]/div/form/div[12]/div').click()
+        browser.find_element_by_xpath('/html/body//form//div[@role="checkbox"]').click()
         submit = browser.find_element_by_xpath('/html/body/div[1]/div/div/div[3]/div/form/div[13]/button')
         if "disabled" in submit.get_attribute('class'):
             browser.execute_script("arguments[0].disabled = false", submit)


### PR DESCRIPTION
将最后的承诺框的定位，由整行修改为只有前面的勾选框